### PR TITLE
Use cloudfront for file server

### DIFF
--- a/loris2.conf
+++ b/loris2.conf
@@ -46,25 +46,11 @@ format = '%(asctime)s (%(name)s) [%(levelname)s]: %(message)s'
 
 [resolver]
 impl = 'loris.resolver.SimpleHTTPResolver'
-source_prefix='http://stanforddailyarchive.s3-website-us-east-1.amazonaws.com/'
+source_prefix='https://d25ls8zm0kyzue.cloudfront.net/'
 source_suffix=''
 cache_root='/usr/local/share/images/loris'
 default_format='jp2'
 head_resolvable=True
-
-
-# Sample config for TemplateHTTResolver config
-
-# [resolver]
-# impl = 'loris.resolver.TemplateHTTPResolver'
-# cache_root='/usr/local/share/images/loris'
-# templates = 's3'
-
-#     [[s3]]
-#     url='http://stanforddailyarchive.s3-website-us-east-1.amazonaws.com/%s'
-# optional settings
-# default_format
-# head_resolvable = False
 
 [img.ImageCache]
 cache_dp = '/var/cache/loris' # rwx


### PR DESCRIPTION
This will really speed up our image distribution.

Cloudfront distribution setup is still in progress; please wait until https://d25ls8zm0kyzue.cloudfront.net/metadata.json works before merging.

See https://github.com/TheStanfordDaily/archives-web/pull/10